### PR TITLE
README.md mod guidelines link correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the public **Mods Index** for Geode. The mods listed here will show up o
 
 ## Getting your mod here
 
-To get your mod listed on the repository, [open a pull request](https://github.com/geode-sdk/mods/compare). We require a copy of the mod's source code so we can verify the mod adheres to our [modding guidelines](https://geode-sdk.github.io/docs/guidelines.html), and we will build the mod that will be released on this repository from the source code ourselves.
+To get your mod listed on the repository, [open a pull request](https://github.com/geode-sdk/mods/compare). We require a copy of the mod's source code so we can verify the mod adheres to our [modding guidelines](https://docs.geode-sdk.org/source/guidelines), and we will build the mod that will be released on this repository from the source code ourselves.
 
 ### Commit naming conventions
 


### PR DESCRIPTION
The current link to the modding guidelines leads to a 404 GitHub pages error, and I have changed it to the new path.